### PR TITLE
Update ISSViewPrototype.m

### DIFF
--- a/InterfaCSS/Model/ISSViewPrototype.m
+++ b/InterfaCSS/Model/ISSViewPrototype.m
@@ -24,12 +24,24 @@
     return prototypeDefinition;
 }
 
+- (UIView*) createViewObjectFromPrototype:(id)parentObject rootObject:(id)rootObject{
+    UIView* view = _viewBuilderBlock();
+    if( [_propertyName iss_hasData] ) [ISSViewHierarchyParser setViewObjectPropertyValue:view withName:_propertyName inParent:rootObject orFileOwner:nil];
+    
+    for (ISSViewPrototype* subviewPrototype in self.subviewPrototypes) {
+        UIView* subview = [subviewPrototype createViewObjectFromPrototype:view rootObject:rootObject];
+        if( subviewPrototype.addAsSubView ) [view addSubview:subview];
+    }
+    return view;
+}
+
+
 - (UIView*) createViewObjectFromPrototype:(id)parentObject {
     UIView* view = _viewBuilderBlock();
     if( [_propertyName iss_hasData] ) [ISSViewHierarchyParser setViewObjectPropertyValue:view withName:_propertyName inParent:parentObject orFileOwner:nil];
 
     for (ISSViewPrototype* subviewPrototype in self.subviewPrototypes) {
-        UIView* subview = [subviewPrototype createViewObjectFromPrototype:view];
+        UIView* subview = [subviewPrototype createViewObjectFromPrototype:view rootObject:view];
         if( subviewPrototype.addAsSubView ) [view addSubview:subview];
     }
     return view;


### PR DESCRIPTION
If xml tags (labels) containing properties are embedded in another view - createViewObjectFromPrototype can not setViewObjectPropertyValue in the implementation.

```
       <PrototypeExampleCell prototype="prototypeExampleCell" class="prototypeExampleCell">
            <view class="group">
                 <label property="label1" class="prototypeExampleCellLabel1"/>
                 <label property="label2" class="prototypeExampleCellLabel2"/>
            </view>
            <label property="label3" class="prototypeExampleCellLabel3"/>

            <!-- Example of how you can directly set the backgroundView and selectedBackgroundView properties of a UITableViewCell: -->
            <view property="backgroundView" class="cellBackgroundView" add="NO"/>
            <view property="selectedBackgroundView" class="cellBackgroundViewSelected" add="NO"/>
        </PrototypeExampleCell>
```
