### PR TITLE
Changed number parser to support an optional negative

### DIFF
--- a/InterfaCSS/Parser/ISSParcoaStyleSheetParser.m
+++ b/InterfaCSS/Parser/ISSParcoaStyleSheetParser.m
@@ -963,6 +963,7 @@
         number = [[Parcoa digit] concatMany1];
         ParcoaParser* fraction = [[dot then:number] concat];
         number = [[number then:[Parcoa option:fraction default:@""]] concat];
+        number = [[[Parcoa option:[Parcoa iss_quickUnichar:'-'] default:@""] then:number] concat];
 
         ParcoaParser* singleQuote = [Parcoa iss_quickUnichar:'\''];
         ParcoaParser* notSingleQuote = [Parcoa iss_anythingButUnichar:'\'' escapesEnabled:YES];


### PR DESCRIPTION
NSAttributedStrings support a negative kern value, but the
ISSPropertyTypeNumber rejects negative numbers

Fixes #30 