### PR TITLE
Update podspec to support tvOS cocoapod integration

### DIFF
--- a/InterfaCSS.podspec
+++ b/InterfaCSS.podspec
@@ -6,8 +6,8 @@ Pod::Spec.new do |s|
   s.license      = 'MIT'
   s.authors      = { 'Tobias Löfstrand' => 'tobias@leafnode.se' }
   s.source       = { :git => 'https://github.com/tolo/InterfaCSS.git', :tag => s.version.to_s }
-  s.platform     = :ios
   s.ios.deployment_target = '6.0'
+  s.tvos.deployment_target = '9.0'
   s.source_files = 'InterfaCSS/**/*.{h,m}'
   s.requires_arc = true
   s.frameworks   = 'Foundation', 'UIKit', 'CoreGraphics', 'QuartzCore'


### PR DESCRIPTION
Based on pending cocoapods branch 'tvos'

gem 'cocoapods', :git => 'https://github.com/CocoaPods/CocoaPods.git', :branch=>'tvos'
gem 'cocoapods-core', :git => 'https://github.com/CocoaPods/Core.git', :branch=>'tvos-support'
gem 'xcodeproj',  :git => 'https://github.com/CocoaPods/Xcodeproj.git', :branch=>'tvos-support'